### PR TITLE
Add Google Site Kit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,18 @@
           "type": "zip"
         }
       }
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "google/site-kit-dev-settings",
+        "version": "0.1.0",
+        "type": "wordpress-plugin",
+        "dist": {
+          "url": "https://sitekit.withgoogle.com/service/download/google-site-kit-dev-settings.zip",
+          "type": "zip"
+        }
+      }
     }
   ],
   "require": {
@@ -34,6 +46,7 @@
     "ataylorme/ataylorme-wordpress-theme": "^1.0.0",
     "composer/installers": "^1.3.0",
     "google/site-kit": "1.0.0-beta.1.0.3",
+    "google/site-kit-dev-settings": "0.1.0",
     "pantheon-systems/quicksilver-pushback": "^1.0.1",
     "pantheon-systems/wordpress-composer": "*",
     "roots/wp-password-bcrypt": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "version": "1.0.0-beta.1.0.3",
         "type": "wordpress-plugin",
         "dist": {
-          "url": "https://github.com/google/site-kit-wp/archive/1.0.0-beta.1.0.3.zip",
+          "url": "https://codeload.github.com/google/site-kit-wp/zip/1.0.0-beta.1.0.3",
           "type": "zip"
         }
       }

--- a/composer.json
+++ b/composer.json
@@ -15,27 +15,45 @@
     {
       "type": "vcs",
       "url": "https://github.com/ataylorme/ataylorme-wordpress-theme"
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "google/site-kit",
+        "version": "1.0.0-beta.1.0.3",
+        "type": "wordpress-plugin",
+        "dist": {
+          "url": "https://github.com/google/site-kit-wp/archive/1.0.0-beta.1.0.3.zip",
+          "type": "zip"
+        },
+        "source": {
+          "url": "https://github.com/google/site-kit-wp",
+          "type": "vcs",
+          "reference": "releases/tag/1.0.0-beta.1.0.3"
+        }
+      }
     }
   ],
   "require": {
     "php": ">=7.3",
+    "ataylorme/ataylorme-wordpress-theme": "^1.0.0",
     "composer/installers": "^1.3.0",
+    "google/site-kit": "1.0.0-beta.1.0.3",
     "pantheon-systems/quicksilver-pushback": "^1.0.1",
     "pantheon-systems/wordpress-composer": "*",
     "roots/wp-password-bcrypt": "^1.0.0",
     "rvtraveller/qs-composer-installer": "^1.1",
     "vlucas/phpdotenv": "^3.1.0",
-    "wpackagist-plugin/pwa": "^0.2.0",
     "wpackagist-plugin/amp": "^1.2.0",
     "wpackagist-plugin/gutenberg": "^6.1.1",
     "wpackagist-plugin/health-check": "^1.3.2",
     "wpackagist-plugin/pantheon-advanced-page-cache": "^0.3.0",
+    "wpackagist-plugin/pwa": "^0.2.0",
+    "wpackagist-plugin/wp-mail-smtp": "^1.4.2",
     "wpackagist-plugin/wp-native-php-sessions": "^0.7.0",
     "wpackagist-plugin/wp-redis": "^0.7.1",
-    "wpackagist-plugin/wp-mail-smtp": "^1.4.2",
     "wpackagist-plugin/wpforms-lite": "^1.5.3",
-    "wpackagist-theme/twentynineteen": "^1.4",
-    "ataylorme/ataylorme-wordpress-theme": "^1.0.0"
+    "wpackagist-theme/twentynineteen": "^1.4"
   },
   "require-dev": {
     "behat/mink-goutte-driver": "^1.2.1",

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,6 @@
         "dist": {
           "url": "https://github.com/google/site-kit-wp/archive/1.0.0-beta.1.0.3.zip",
           "type": "zip"
-        },
-        "source": {
-          "url": "https://github.com/google/site-kit-wp",
-          "type": "vcs",
-          "reference": "releases/tag/1.0.0-beta.1.0.3"
         }
       }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36e22442783975098d72e3f0f7f52c41",
+    "content-hash": "aaf531c18a00fcb90735ef1ae8196ba2",
     "packages": [
         {
             "name": "ataylorme/ataylorme-wordpress-theme",
@@ -194,6 +194,15 @@
                 "type": "zip",
                 "url": "https://github.com/google/site-kit-wp/archive/1.0.0-beta.1.0.3.zip",
                 "reference": "releases/tag/1.0.0-beta.1.0.3"
+            },
+            "type": "wordpress-plugin"
+        },
+        {
+            "name": "google/site-kit-dev-settings",
+            "version": "0.1.0",
+            "dist": {
+                "type": "zip",
+                "url": "https://sitekit.withgoogle.com/service/download/google-site-kit-dev-settings.zip"
             },
             "type": "wordpress-plugin"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b47caebe2114d7842bf160b8787e017e",
+    "content-hash": "36e22442783975098d72e3f0f7f52c41",
     "packages": [
         {
             "name": "ataylorme/ataylorme-wordpress-theme",
@@ -190,11 +190,6 @@
         {
             "name": "google/site-kit",
             "version": "1.0.0-beta.1.0.3",
-            "source": {
-                "type": "vcs",
-                "url": "https://github.com/google/site-kit-wp",
-                "reference": "releases/tag/1.0.0-beta.1.0.3"
-            },
             "dist": {
                 "type": "zip",
                 "url": "https://github.com/google/site-kit-wp/archive/1.0.0-beta.1.0.3.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe8fc88b2a79265c258949d2a9b83967",
+    "content-hash": "b47caebe2114d7842bf160b8787e017e",
     "packages": [
         {
             "name": "ataylorme/ataylorme-wordpress-theme",
@@ -186,6 +186,21 @@
                 "zikula"
             ],
             "time": "2018-08-27T06:10:37+00:00"
+        },
+        {
+            "name": "google/site-kit",
+            "version": "1.0.0-beta.1.0.3",
+            "source": {
+                "type": "vcs",
+                "url": "https://github.com/google/site-kit-wp",
+                "reference": "releases/tag/1.0.0-beta.1.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/google/site-kit-wp/archive/1.0.0-beta.1.0.3.zip",
+                "reference": "releases/tag/1.0.0-beta.1.0.3"
+            },
+            "type": "wordpress-plugin"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -569,15 +584,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "6.1.1",
+            "version": "6.2.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/6.1.1"
+                "reference": "tags/6.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.6.1.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.6.2.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -695,15 +710,15 @@
         },
         {
             "name": "wpackagist-plugin/wpforms-lite",
-            "version": "1.5.3.1",
+            "version": "1.5.4.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wpforms-lite/",
-                "reference": "tags/1.5.3.1"
+                "reference": "tags/1.5.4.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wpforms-lite.1.5.3.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/wpforms-lite.1.5.4.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -5264,6 +5279,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "google/site-kit": 10,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aaf531c18a00fcb90735ef1ae8196ba2",
+    "content-hash": "f36b4ec83e6e1c60b887380369d4bc6a",
     "packages": [
         {
             "name": "ataylorme/ataylorme-wordpress-theme",
@@ -192,8 +192,7 @@
             "version": "1.0.0-beta.1.0.3",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/google/site-kit-wp/archive/1.0.0-beta.1.0.3.zip",
-                "reference": "releases/tag/1.0.0-beta.1.0.3"
+                "url": "https://codeload.github.com/google/site-kit-wp/zip/1.0.0-beta.1.0.3"
             },
             "type": "wordpress-plugin"
         },
@@ -2843,16 +2842,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.2.5",
+            "version": "8.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c1b8534b3730f20f58600124129197bf1183dc92"
+                "reference": "e77a49b6da82240f40ddd4be536d30d7dae5c168"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c1b8534b3730f20f58600124129197bf1183dc92",
-                "reference": "c1b8534b3730f20f58600124129197bf1183dc92",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e77a49b6da82240f40ddd4be536d30d7dae5c168",
+                "reference": "e77a49b6da82240f40ddd4be536d30d7dae5c168",
                 "shasum": ""
             },
             "require": {
@@ -2868,7 +2867,7 @@
                 "phar-io/version": "^2.0.1",
                 "php": "^7.2",
                 "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^7.0.5",
+                "phpunit/php-code-coverage": "^7.0.7",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
@@ -2896,7 +2895,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.2-dev"
+                    "dev-master": "8.3-dev"
                 }
             },
             "autoload": {
@@ -2911,8 +2910,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -2922,7 +2921,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-15T06:26:24+00:00"
+            "time": "2019-08-02T13:42:49+00:00"
         },
         {
             "name": "psr/container",

--- a/scripts/composer/cleanup-composer
+++ b/scripts/composer/cleanup-composer
@@ -14,3 +14,11 @@ fi
 if [ -d "web/wp/wp-content" ]; then
   rm -rf web/wp/wp-content
 fi
+
+
+if [ -d "web/wp-content/plugins/site-kit-dev-settings/google-site-kit-dev-settings" ]; then
+  mv web/wp-content/plugins/site-kit-dev-settings/google-site-kit-dev-settings/* web/wp-content/plugins/site-kit-dev-settings/
+  ls web/wp-content/plugins/site-kit-dev-settings/google-site-kit-dev-settings
+  rm -rf web/wp-content/plugins/site-kit-dev-settings/google-site-kit-dev-settings
+  rm -rf web/wp-content/plugins/site-kit-dev-settings/__MACOSX
+fi


### PR DESCRIPTION
https://github.com/google/site-kit-wp/pull/42 and https://github.com/pantheon-systems/wordpress-composer/pull/5 need to be resolved, tagged versions used, and `stability:dev` removed before this PR can be merged