### PR TITLE
Update Composer dependencies (2019-08-29-00-08)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -579,15 +579,15 @@
         },
         {
             "name": "wpackagist-plugin/amp",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/amp/",
-                "reference": "tags/1.2.1"
+                "reference": "tags/1.2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/amp.1.2.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/amp.1.2.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -597,15 +597,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "6.3.0",
+            "version": "6.4.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/6.3.0"
+                "reference": "tags/6.4.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.6.3.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.6.4.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"


### PR DESCRIPTION
```
Loading composer repositories with package information
                                                      Updating dependencies (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Updating wpackagist-plugin/amp (1.2.1 => 1.2.2): Downloading (100%)
  - Updating wpackagist-plugin/gutenberg (6.3.0 => 6.4.0): Downloading (100%)
Writing lock file
Generating optimized autoload files
ocramius/package-versions: Generating version class...
ocramius/package-versions: ...done generating version class
PHP CodeSniffer Config installed_paths set to ../../wp-coding-standards/wpcs
> ./scripts/composer/cleanup-composer
+ '[' -d web/wp/wp-content/mu-plugins/ ']'
+ '[' -f web/wp/wp-config.php ']'
+ '[' -d web/wp/wp-content ']'
+ '[' -d web/wp-content/plugins/site-kit-dev-settings/google-site-kit-dev-settings ']'
> WordPressProject\composer\ScriptHandler::createRequiredFiles
```