### PR TITLE
Update Composer dependencies (2019-10-25-00-08)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -705,15 +705,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-mail-smtp",
-            "version": "1.6.2",
+            "version": "1.7.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-mail-smtp/",
-                "reference": "tags/1.6.2"
+                "reference": "tags/1.7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.1.6.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.1.7.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -759,15 +759,15 @@
         },
         {
             "name": "wpackagist-plugin/wpforms-lite",
-            "version": "1.5.5.1",
+            "version": "1.5.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wpforms-lite/",
-                "reference": "tags/1.5.5.1"
+                "reference": "tags/1.5.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wpforms-lite.1.5.5.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/wpforms-lite.1.5.6.zip"
             },
             "require": {
                 "composer/installers": "~1.0"


### PR DESCRIPTION
```
Loading composer repositories with package information
                                                      Updating dependencies (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Updating wpackagist-plugin/wp-mail-smtp (1.6.2 => 1.7.0): Downloading (100%)
  - Updating wpackagist-plugin/wpforms-lite (1.5.5.1 => 1.5.6): Downloading (100%)
Writing lock file
Generating optimized autoload files
ocramius/package-versions: Generating version class...
ocramius/package-versions: ...done generating version class
PHP CodeSniffer Config installed_paths set to ../../wp-coding-standards/wpcs
> ./scripts/composer/cleanup-composer
+ '[' -d web/wp/wp-content/mu-plugins/ ']'
+ '[' -f web/wp/wp-config.php ']'
+ '[' -d web/wp/wp-content ']'
+ '[' -d web/wp-content/plugins/site-kit-dev-settings/google-site-kit-dev-settings ']'
> WordPressProject\composer\ScriptHandler::createRequiredFiles
```