### PR TITLE
Update Composer dependencies (2019-12-12-00-07)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -319,16 +319,16 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "f4e7a6a1382183412246f0d361078c29fb85089e"
+                "reference": "a8593bf5176bf3d3f2966942c530be19b44ec87c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/f4e7a6a1382183412246f0d361078c29fb85089e",
-                "reference": "f4e7a6a1382183412246f0d361078c29fb85089e",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/a8593bf5176bf3d3f2966942c530be19b44ec87c",
+                "reference": "a8593bf5176bf3d3f2966942c530be19b44ec87c",
                 "shasum": ""
             },
             "require": {
@@ -369,7 +369,7 @@
                 "php",
                 "type"
             ],
-            "time": "2019-11-30T20:20:49+00:00"
+            "time": "2019-12-11T13:45:14+00:00"
         },
         {
             "name": "roots/wp-password-bcrypt",


### PR DESCRIPTION
```
Loading composer repositories with package information
                                                      Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating phpoption/phpoption (1.6.0 => 1.6.1): Downloading (100%)
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Writing lock file
Generating optimized autoload files
ocramius/package-versions: Generating version class...
ocramius/package-versions: ...done generating version class
PHP CodeSniffer Config installed_paths set to ../../wp-coding-standards/wpcs
> ./scripts/composer/cleanup-composer
+ '[' -d web/wp/wp-content/mu-plugins/ ']'
+ '[' -f web/wp/wp-config.php ']'
+ '[' -d web/wp/wp-content ']'
+ '[' -d web/wp-content/plugins/site-kit-dev-settings/google-site-kit-dev-settings ']'
> WordPressProject\composer\ScriptHandler::createRequiredFiles
```